### PR TITLE
Fix: Preserve scroll position when navigating back to Home

### DIFF
--- a/lib/controller/bloc/news_scroll_bloc/news_scroll_bloc.dart
+++ b/lib/controller/bloc/news_scroll_bloc/news_scroll_bloc.dart
@@ -1,32 +1,32 @@
 import 'dart:async';
-import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:brevity/controller/bloc/news_scroll_bloc/news_scroll_event.dart';
-import 'package:brevity/controller/bloc/news_scroll_bloc/news_scroll_state.dart';
-import 'package:brevity/controller/services/news_services.dart';
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
 import 'package:brevity/models/article_model.dart';
 import 'package:brevity/models/news_category.dart';
+import 'package:brevity/controller/services/news_services.dart';
+
+part 'news_scroll_event.dart';
+part 'news_scroll_state.dart';
 
 class NewsBloc extends Bloc<NewsEvent, NewsState> {
   final NewsService newsService;
   int _page = 1;
-  bool _hasReachedMax = false;
   final int _pageSize = 10;
   NewsCategory _currentCategory = NewsCategory.general;
 
   NewsBloc({required this.newsService}) : super(NewsInitial()) {
     on<FetchInitialNews>(_onFetchInitialNews);
     on<FetchNextPage>(_onFetchNextPage);
+    on<UpdateNewsIndex>(_onUpdateNewsIndex);
   }
 
   Future<void> _onFetchInitialNews(
-    FetchInitialNews event,
-    Emitter<NewsState> emit,
-  ) async {
+      FetchInitialNews event,
+      Emitter<NewsState> emit,
+      ) async {
     try {
       _currentCategory = event.category;
       _page = 1;
-      _hasReachedMax = false;
 
       emit(NewsLoading());
       final articles = await _fetchCategoryNews();
@@ -35,6 +35,7 @@ class NewsBloc extends Bloc<NewsEvent, NewsState> {
           articles: articles,
           hasReachedMax: articles.length < _pageSize,
           category: _currentCategory,
+          currentIndex: 0,
         ),
       );
     } catch (e) {
@@ -43,12 +44,13 @@ class NewsBloc extends Bloc<NewsEvent, NewsState> {
   }
 
   Future<void> _onFetchNextPage(
-    FetchNextPage event,
-    Emitter<NewsState> emit,
-  ) async {
+      FetchNextPage event,
+      Emitter<NewsState> emit,
+      ) async {
     final currentState = state;
     if (currentState is! NewsLoaded ||
-        _hasReachedMax ||
+        currentState.hasReachedMax ||
+        currentState.isLoadingMore ||
         _currentCategory != event.category) {
       return;
     }
@@ -56,21 +58,29 @@ class NewsBloc extends Bloc<NewsEvent, NewsState> {
     try {
       emit(currentState.copyWith(isLoadingMore: true));
 
-      final newArticles = await _fetchCategoryNews(page: _page + 1);
-
-      _hasReachedMax = newArticles.length < _pageSize;
       _page++;
+      final newArticles = await _fetchCategoryNews(page: _page);
 
       emit(
-        NewsLoaded(
-          articles: [...currentState.articles, ...newArticles],
-          hasReachedMax: _hasReachedMax,
+        currentState.copyWith(
+          articles: List.of(currentState.articles)..addAll(newArticles),
+          hasReachedMax: newArticles.length < _pageSize,
           isLoadingMore: false,
-          category: _currentCategory,
         ),
       );
     } catch (e) {
-      emit(NewsError('Failed to load more news: $e'));
+      _page--;
+      emit(currentState.copyWith(isLoadingMore: false));
+    }
+  }
+
+  void _onUpdateNewsIndex(
+      UpdateNewsIndex event,
+      Emitter<NewsState> emit,
+      ) {
+    if (state is NewsLoaded) {
+      final currentState = state as NewsLoaded;
+      emit(currentState.copyWith(currentIndex: event.newIndex));
     }
   }
 

--- a/lib/controller/bloc/news_scroll_bloc/news_scroll_event.dart
+++ b/lib/controller/bloc/news_scroll_bloc/news_scroll_event.dart
@@ -1,14 +1,33 @@
-import 'package:brevity/models/news_category.dart';
+part of 'news_scroll_bloc.dart';
 
-abstract class NewsEvent {}
+abstract class NewsEvent extends Equatable {
+  const NewsEvent();
+
+  @override
+  List<Object> get props => [];
+}
 
 class FetchInitialNews extends NewsEvent {
   final NewsCategory category;
-  FetchInitialNews({this.category = NewsCategory.general});
+  const FetchInitialNews({this.category = NewsCategory.general});
+
+  @override
+  List<Object> get props => [category];
 }
 
 class FetchNextPage extends NewsEvent {
   final int currentIndex;
   final NewsCategory category;
-  FetchNextPage(this.currentIndex, this.category);
+  const FetchNextPage(this.currentIndex, this.category);
+
+  @override
+  List<Object> get props => [currentIndex, category];
+}
+
+class UpdateNewsIndex extends NewsEvent {
+  final int newIndex;
+  const UpdateNewsIndex(this.newIndex);
+
+  @override
+  List<Object> get props => [newIndex];
 }

--- a/lib/controller/bloc/news_scroll_bloc/news_scroll_state.dart
+++ b/lib/controller/bloc/news_scroll_bloc/news_scroll_state.dart
@@ -1,10 +1,8 @@
-import 'package:equatable/equatable.dart';
-import 'package:brevity/models/article_model.dart';
-import 'package:brevity/models/news_category.dart';
+part of 'news_scroll_bloc.dart';
 
 abstract class NewsState extends Equatable {
   const NewsState();
-  
+
   @override
   List<Object> get props => [];
 }
@@ -18,12 +16,14 @@ class NewsLoaded extends NewsState {
   final bool hasReachedMax;
   final bool isLoadingMore;
   final NewsCategory category;
+  final int currentIndex;
 
   const NewsLoaded({
     required this.articles,
     this.hasReachedMax = false,
     this.isLoadingMore = false,
     required this.category,
+    this.currentIndex = 0,
   });
 
   NewsLoaded copyWith({
@@ -31,17 +31,25 @@ class NewsLoaded extends NewsState {
     bool? hasReachedMax,
     bool? isLoadingMore,
     NewsCategory? category,
+    int? currentIndex,
   }) {
     return NewsLoaded(
       articles: articles ?? this.articles,
       hasReachedMax: hasReachedMax ?? this.hasReachedMax,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       category: category ?? this.category,
+      currentIndex: currentIndex ?? this.currentIndex,
     );
   }
 
   @override
-  List<Object> get props => [articles, hasReachedMax, isLoadingMore, category];
+  List<Object> get props => [
+    articles,
+    hasReachedMax,
+    isLoadingMore,
+    category,
+    currentIndex,
+  ];
 }
 
 class NewsError extends NewsState {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:brevity/controller/services/firestore_service.dart';
 import 'package:brevity/controller/cubit/user_profile/user_profile_cubit.dart';
 import 'package:brevity/views/inner_screens/contact_screen.dart';
+import 'package:brevity/controller/bloc/news_scroll_bloc/news_scroll_bloc.dart';
 
 // Create a class to manage authentication state
 class AuthService {
@@ -94,162 +95,162 @@ final _routes = GoRouter(
       name: 'sidepage',
       pageBuilder:
           (context, state) => CustomTransitionPage(
-            key: state.pageKey,
-            child: const SidePage(),
-            transitionsBuilder: (
-              context,
-              animation,
-              secondaryAnimation,
-              child,
+        key: state.pageKey,
+        child: const SidePage(),
+        transitionsBuilder: (
+            context,
+            animation,
+            secondaryAnimation,
+            child,
             ) {
-              const begin = Offset(-1.0, 0.0);
-              const end = Offset.zero;
-              const curve = Curves.easeInOut;
-              return SlideTransition(
-                position: Tween(
-                  begin: begin,
-                  end: end,
-                ).chain(CurveTween(curve: curve)).animate(animation),
-                child: child,
-              );
-            },
-            transitionDuration: const Duration(milliseconds: 225),
-          ),
+          const begin = Offset(-1.0, 0.0);
+          const end = Offset.zero;
+          const curve = Curves.easeInOut;
+          return SlideTransition(
+            position: Tween(
+              begin: begin,
+              end: end,
+            ).chain(CurveTween(curve: curve)).animate(animation),
+            child: child,
+          );
+        },
+        transitionDuration: const Duration(milliseconds: 225),
+      ),
       routes: [
         GoRoute(
           path: 'bookmark',
           name: 'bookmark',
           pageBuilder:
               (context, state) => CustomTransitionPage(
-                key: state.pageKey,
-                child: const BookmarkScreen(),
-                transitionsBuilder: (
-                  context,
-                  animation,
-                  secondaryAnimation,
-                  child,
+            key: state.pageKey,
+            child: const BookmarkScreen(),
+            transitionsBuilder: (
+                context,
+                animation,
+                secondaryAnimation,
+                child,
                 ) {
-                  // Combine scale and fade animations
-                  return Align(
-                    alignment: Alignment.center,
-                    child: FadeTransition(
-                      opacity: animation,
-                      child: ScaleTransition(
-                        scale: animation.drive(
-                          Tween<double>(
-                            begin: 0.0,
-                            end: 1.0,
-                          ).chain(CurveTween(curve: Curves.easeInOutQuad)),
-                        ),
-                        child: child,
-                      ),
+              // Combine scale and fade animations
+              return Align(
+                alignment: Alignment.center,
+                child: FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(
+                    scale: animation.drive(
+                      Tween<double>(
+                        begin: 0.0,
+                        end: 1.0,
+                      ).chain(CurveTween(curve: Curves.easeInOutQuad)),
                     ),
-                  );
-                },
-                transitionDuration: const Duration(milliseconds: 225),
-              ),
+                    child: child,
+                  ),
+                ),
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 225),
+          ),
         ),
         GoRoute(
           path: '/settings',
           name: 'settings',
           pageBuilder:
               (context, state) => CustomTransitionPage(
-                key: state.pageKey,
-                child: const SettingsScreen(),
-                transitionsBuilder: (
-                  context,
-                  animation,
-                  secondaryAnimation,
-                  child,
+            key: state.pageKey,
+            child: const SettingsScreen(),
+            transitionsBuilder: (
+                context,
+                animation,
+                secondaryAnimation,
+                child,
                 ) {
-                  return Align(
-                    alignment: Alignment.center,
-                    child: FadeTransition(
-                      opacity: animation,
-                      child: ScaleTransition(
-                        scale: animation.drive(
-                          Tween<double>(
-                            begin: 0.0,
-                            end: 1.0,
-                          ).chain(CurveTween(curve: Curves.easeInOutQuad)),
-                        ),
-                        child: child,
-                      ),
+              return Align(
+                alignment: Alignment.center,
+                child: FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(
+                    scale: animation.drive(
+                      Tween<double>(
+                        begin: 0.0,
+                        end: 1.0,
+                      ).chain(CurveTween(curve: Curves.easeInOutQuad)),
                     ),
-                  );
-                },
-                transitionDuration: const Duration(milliseconds: 225),
-              ),
+                    child: child,
+                  ),
+                ),
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 225),
+          ),
         ),
         GoRoute(
           path: '/profile',
           name: 'profile',
           pageBuilder:
               (context, state) => CustomTransitionPage(
-                key: state.pageKey,
-                child: const ProfileScreen(),
-                transitionsBuilder: (
-                  context,
-                  animation,
-                  secondaryAnimation,
-                  child,
+            key: state.pageKey,
+            child: const ProfileScreen(),
+            transitionsBuilder: (
+                context,
+                animation,
+                secondaryAnimation,
+                child,
                 ) {
-                  return Align(
-                    alignment: Alignment.center,
-                    child: FadeTransition(
-                      opacity: animation,
-                      child: ScaleTransition(
-                        scale: animation.drive(
-                          Tween<double>(
-                            begin: 0.0,
-                            end: 1.0,
-                          ).chain(CurveTween(curve: Curves.easeInOutQuad)),
-                        ),
-                        child: child,
-                      ),
+              return Align(
+                alignment: Alignment.center,
+                child: FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(
+                    scale: animation.drive(
+                      Tween<double>(
+                        begin: 0.0,
+                        end: 1.0,
+                      ).chain(CurveTween(curve: Curves.easeInOutQuad)),
                     ),
-                  );
-                },
-                transitionDuration: const Duration(milliseconds: 225),
-              ),
+                    child: child,
+                  ),
+                ),
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 225),
+          ),
         ),
         GoRoute(
           path: '/searchResults',
           name: 'searchResults',
           pageBuilder:
               (context, state) => CustomTransitionPage(
-                key: state.pageKey,
-                child: SearchResultsScreen(
-                  query:
-                      state
-                          .uri
-                          .queryParameters['query']!, // Only query parameter
-                ),
-                transitionsBuilder: (
-                  context,
-                  animation,
-                  secondaryAnimation,
-                  child,
+            key: state.pageKey,
+            child: SearchResultsScreen(
+              query:
+              state
+                  .uri
+                  .queryParameters['query']!, // Only query parameter
+            ),
+            transitionsBuilder: (
+                context,
+                animation,
+                secondaryAnimation,
+                child,
                 ) {
-                  // Combine scale and fade animations
-                  return Align(
-                    alignment: Alignment.center,
-                    child: FadeTransition(
-                      opacity: animation,
-                      child: ScaleTransition(
-                        scale: animation.drive(
-                          Tween<double>(
-                            begin: 0.0,
-                            end: 1.0,
-                          ).chain(CurveTween(curve: Curves.easeInOutQuad)),
-                        ),
-                        child: child,
-                      ),
+              // Combine scale and fade animations
+              return Align(
+                alignment: Alignment.center,
+                child: FadeTransition(
+                  opacity: animation,
+                  child: ScaleTransition(
+                    scale: animation.drive(
+                      Tween<double>(
+                        begin: 0.0,
+                        end: 1.0,
+                      ).chain(CurveTween(curve: Curves.easeInOutQuad)),
                     ),
-                  );
-                },
-                transitionDuration: const Duration(milliseconds: 225),
-              ),
+                    child: child,
+                  ),
+                ),
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 225),
+          ),
         ),
       ],
     ),
@@ -284,33 +285,33 @@ final _routes = GoRouter(
       name: 'chat',
       pageBuilder:
           (context, state) => CustomTransitionPage(
-            key: state.pageKey,
-            child: ChatScreen(article: state.extra as Article),
-            transitionsBuilder: (
-              context,
-              animation,
-              secondaryAnimation,
-              child,
+        key: state.pageKey,
+        child: ChatScreen(article: state.extra as Article),
+        transitionsBuilder: (
+            context,
+            animation,
+            secondaryAnimation,
+            child,
             ) {
-              // Combine scale and fade animations
-              return Align(
-                alignment: Alignment.center,
-                child: FadeTransition(
-                  opacity: animation,
-                  child: ScaleTransition(
-                    scale: animation.drive(
-                      Tween<double>(
-                        begin: 0.0,
-                        end: 1.0,
-                      ).chain(CurveTween(curve: Curves.easeInOutQuad)),
-                    ),
-                    child: child,
-                  ),
+          // Combine scale and fade animations
+          return Align(
+            alignment: Alignment.center,
+            child: FadeTransition(
+              opacity: animation,
+              child: ScaleTransition(
+                scale: animation.drive(
+                  Tween<double>(
+                    begin: 0.0,
+                    end: 1.0,
+                  ).chain(CurveTween(curve: Curves.easeInOutQuad)),
                 ),
-              );
-            },
-            transitionDuration: const Duration(milliseconds: 225),
-          ),
+                child: child,
+              ),
+            ),
+          );
+        },
+        transitionDuration: const Duration(milliseconds: 225),
+      ),
     ),
   ],
   // Add redirect logic to handle authentication state
@@ -358,6 +359,8 @@ void main() async {
       ],
       child: MultiBlocProvider(
         providers: [
+          // THIS IS THE CRITICAL FIX: PROVIDING THE NEWSBLOC GLOBALLY
+          BlocProvider(create: (context) => NewsBloc(newsService: newsService)),
           BlocProvider(create: (context) => BookmarkBloc(bookmarkRepository)),
           BlocProvider(create: (context) => UserProfileCubit()),
           BlocProvider(create: (context) => ThemeCubit()..initializeTheme()),


### PR DESCRIPTION
##Resolves the issue where the home screen feed would reset to the first article after navigating to another page and returning.

This was caused by the NewsBloc being tied to the HomeScreen's lifecycle.

Changes:
1. The NewsBloc is now provided globally in main.dart to ensure its state persists across the app.
2. The NewsLoaded state now tracks the currentIndex of the card swiper.
3. The UI now uses the currentIndex from the BLoC to restore the swiper's position when the screen is revisited.

https://github.com/user-attachments/assets/a30a91c3-4287-43f2-be34-48e90800804e

