### PR TITLE
Added Figma UI reference file in assets

### DIFF
--- a/assets/figma_ui_screens.txt
+++ b/assets/figma_ui_screens.txt
@@ -1,0 +1,11 @@
+Screens Included (Both Light & Dark Themes):
+- Opening Screen
+- Login Screen
+- Sign-Up Screen  
+
+Figma Link: https://www.figma.com/design/6ABmbnL1y5dxYylmxpJHvO/Brevity-GSSoC--25?node-id=0-1&t=mdxv3tSQSQ4nYrhO-1
+
+Notes:
+- This design covers both light and dark themes for consistency.
+- Use this reference when implementing theme switching in the app.
+- Ensure you have Figma access permissions before opening.


### PR DESCRIPTION
# 📌 Pull Request Template

## 📝 Description
Added a reference text file in `assets/` that contains the Figma project link for the Login, Sign-Up, and Opening screens in both Light and Dark themes.  
This ensures developers can easily access the UI/UX design files during implementation. 

## 🔄 Changes Made
<!-- List the key changes introduced in this PR. Use bullet points. -->

## 📎 Proof of Work (Mandatory)
- Created `assets/figma_ui_screens.txt`  
- Documented the Figma link  - https://www.figma.com/design/6ABmbnL1y5dxYylmxpJHvO/Brevity-GSSoC--25?node-id=0-1&t=mdxv3tSQSQ4nYrhO-1
