### PR TITLE
Share news feature

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -56,7 +56,7 @@ android {
 
     defaultConfig {
         applicationId = "com.unity.brevity"
-        minSdk = 23
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="brevity" />
+            </intent-filter>
         </activity>
 
         <!-- THEME FOR CROPPER ACTIVITY IS NOW FIXED -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,5 +50,16 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.brevity.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>brevity</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/controller/bloc/bookmark_bloc/bookmark_bloc.dart
+++ b/lib/controller/bloc/bookmark_bloc/bookmark_bloc.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:brevity/utils/logger.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:brevity/controller/services/bookmark_services.dart';
 import 'bookmark_event.dart';
@@ -56,6 +57,6 @@ class BookmarkBloc extends Bloc<BookmarkEvent, BookmarkState> {
 
   void _log(String message) {
     // Centralized logging format
-    print("BOOKMARK_BLOC:$message");
+    Log.d("BOOKMARK_BLOC:$message");
   }
 }

--- a/lib/controller/bloc/chat_bloc/chat_bloc.dart
+++ b/lib/controller/bloc/chat_bloc/chat_bloc.dart
@@ -71,7 +71,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         timestamp: DateTime.now(),
       );
 
-  Log.d('<CHAT_BLOC> New Conversation created: requestPreview="${event.message.length > 120 ? event.message.substring(0, 120) + '...' : event.message}"');
+  Log.d('<CHAT_BLOC> New Conversation created: requestPreview="${event.message.length > 120 ? '${event.message.substring(0, 120)}...' : event.message}"');
 
       // Add conversation to chat window
       final updatedConversations = [

--- a/lib/views/auth/signup.dart
+++ b/lib/views/auth/signup.dart
@@ -656,10 +656,8 @@ class _SignupScreenState extends State<SignupScreen>
                               isValid: _nameValid,
                               errorText: _nameError,
                               validator: (v) {
-                                if (v == null || v.isEmpty)
-                                  return 'Name is required';
-                                if (v.length < 2)
-                                  return 'Name must be at least 2 characters';
+                                if (v == null || v.isEmpty) return 'Name is required';
+                                if (v.length < 2) return 'Name must be at least 2 characters';
                                 return null;
                               },
                             ),

--- a/lib/views/inner_screens/shared_news_screen.dart
+++ b/lib/views/inner_screens/shared_news_screen.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:brevity/controller/services/backend_service.dart' as backend;
+import 'package:brevity/models/article_model.dart';
+import 'package:brevity/utils/logger.dart';
+import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:intl/intl.dart';
+import 'package:gap/gap.dart';
+import 'package:brevity/controller/cubit/theme/theme_cubit.dart';
+
+class SharedNewsScreen extends StatefulWidget {
+  final String newsId;
+
+  const SharedNewsScreen({super.key, required this.newsId});
+
+  @override
+  State<SharedNewsScreen> createState() => _SharedNewsScreenState();
+}
+
+class _SharedNewsScreenState extends State<SharedNewsScreen> {
+  Article? _article;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadNews();
+  }
+
+  Future<void> _loadNews() async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+
+      final response = await backend.ApiService().getNewsById(widget.newsId);
+
+      if (response.success && response.data != null) {
+        Map<String, dynamic> articleJson;
+        try {
+          if (response.data is Map &&
+              (response.data as Map).containsKey('data')) {
+            articleJson = Map<String, dynamic>.from(response.data['data']);
+          } else {
+            articleJson = Map<String, dynamic>.from(response.data as Map);
+          }
+        } catch (e) {
+          Log.e('SharedNewsScreen: Unexpected response data shape', e);
+          setState(() {
+            _error = 'Invalid data received from server.';
+            _isLoading = false;
+          });
+          return;
+        }
+
+        Log.d('SharedNewsScreen: Article JSON: $articleJson');
+
+        setState(() {
+          _article = Article.fromJson(articleJson);
+          _isLoading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load news article.';
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      Log.e('Error loading shared news', e);
+      setState(() {
+        _error = 'An error occurred while loading the article.';
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Shared News'),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.goNamed('sidepage'),
+        ),
+      ),
+      body: _buildContent(),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 64, color: Colors.red),
+            const Gap(16),
+            Text(
+              _error!,
+              style: const TextStyle(fontSize: 16),
+              textAlign: TextAlign.center,
+            ),
+            const Gap(24),
+            ElevatedButton(
+              onPressed: _loadNews,
+              child: const Text('Try Again'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_article == null) {
+      return const Center(child: Text('News article not found'));
+    }
+
+    return _buildNewsDetail();
+  }
+
+  Widget _buildNewsDetail() {
+    final currentTheme = context.read<ThemeCubit>().currentTheme;
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Article image
+          if (_article!.urlToImage.isNotEmpty)
+            CachedNetworkImage(
+              imageUrl: _article!.urlToImage,
+              height: 250,
+              width: double.infinity,
+              fit: BoxFit.cover,
+              placeholder:
+                  (context, url) => Container(
+                    height: 250,
+                    color: Colors.grey[300],
+                    child: const Center(child: CircularProgressIndicator()),
+                  ),
+              errorWidget:
+                  (context, url, error) => Container(
+                    height: 250,
+                    color: Colors.grey[300],
+                    child: const Icon(Icons.image_not_supported, size: 64),
+                  ),
+            ),
+
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Source and date
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: currentTheme.primaryColor,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        _article!.sourceName.toUpperCase(),
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 11,
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: 1.2,
+                        ),
+                      ),
+                    ),
+                    const Gap(12),
+                    Expanded(
+                      child: Text(
+                        DateFormat(
+                          'MMM dd, y • h:mm a',
+                        ).format(_article!.publishedAt),
+                        style: TextStyle(
+                          color: Colors.white.withAlpha(229),
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+
+                const Gap(16),
+
+                // Title
+                Text(
+                  _article!.title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+
+                const Gap(16),
+
+                // Description
+                Text(
+                  _article!.description,
+                  style: TextStyle(
+                    color: Colors.white.withAlpha(229),
+                    fontSize: 16,
+                    height: 1.4,
+                  ),
+                ),
+
+                const Gap(16),
+
+                // Content
+                if (_article!.content.isNotEmpty)
+                  Text(
+                    _article!.content.split('[')[0].trim(),
+                    style: TextStyle(
+                      color: Colors.white.withAlpha(229),
+                      fontSize: 16,
+                      height: 1.5,
+                    ),
+                  ),
+
+                const Gap(24),
+
+                // Author
+                if (_article!.author.isNotEmpty)
+                  Text(
+                    'By ${_article!.author}',
+                    style: TextStyle(
+                      color: Colors.white.withAlpha((0.6 * 255).toInt()),
+                      fontSize: 13,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
+
+                const Gap(32),
+
+                // Read full article button
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: () async {
+                      if (_article!.url.isNotEmpty) {
+                        final uri = Uri.parse(_article!.url);
+                        try {
+                          if (!await launchUrl(uri)) {
+                            throw 'Could not launch ${_article!.url}';
+                          }
+                        } catch (e) {
+                          Log.e('Error launching URL', e);
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text('Could not open the article.'),
+                              ),
+                            );
+                          }
+                        }
+                      }
+                    },
+                    icon: const Icon(Icons.open_in_new),
+                    label: const Text('Read Full Article'),
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      backgroundColor: currentTheme.primaryColor,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.59"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -480,6 +512,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.4+4"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   http:
     dependency: "direct main"
     description:
@@ -612,26 +652,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -1009,10 +1049,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   timezone:
     dependency: "direct main"
     description:
@@ -1113,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   google_fonts: ^6.3.0
   image_cropper: ^9.1.0
   tutorial_coach_mark: ^1.3.1
+  app_links: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION

# Pull request — share-news-feature

This PR body was generated from `.github/pull_request_template.md` and populated with the current branch diff. Use it as the PR description when opening the pull request from branch `share-news-feature` into your main branch.

## Description

Adds an article "share" workflow and deep-link handling so users can share articles via the backend and recipients can open shared articles inside the app using a brevity:// deep link.

Key capabilities added:
- Share button in the Home article card that calls backend share API, receives a share id and produces a brevity://share?id=<id> deep link.
- Backend client additions: `ApiService.shareArticle(...)` and `ApiService.getNewsById(...)` to post shared articles and fetch by id.
- New UI: `SharedNewsScreen` to render articles fetched by share id.
- Deep link plumbing in `main.dart` (AppLinks integration, route `/share`, `DeepLinkHandler`).
- Android and iOS manifest/plist updates to support the custom URL scheme `brevity`.
- Pubspec changes to add `app_links` and adjust dependencies.

## Related issue / ticket

- Branch: `share-news-feature`
- #254 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] CI / infra